### PR TITLE
Update __init__.py

### DIFF
--- a/flask_cloud_ndb/__init__.py
+++ b/flask_cloud_ndb/__init__.py
@@ -7,7 +7,7 @@ Adds Google Cloud NDB support to Flask
 
 import os
 
-from google.auth._default import _load_credentials_from_file
+from google.auth._default import load_credentials_from_file
 from google.cloud import ndb
 
 
@@ -63,7 +63,7 @@ class CloudNDB(object):
             credentials_file = app.config["NDB_GOOGLE_APPLICATION_CREDENTIALS"]
             if credentials_file:
                 # call google auth helper to initialise credentials
-                credentials, project_id = _load_credentials_from_file(
+                credentials, project_id = load_credentials_from_file(
                     credentials_file)
             else:
                 # default credentials, OR load from env, through underlying


### PR DESCRIPTION
The file flask_cloud_ndb/__init__.py "line 10" there is a typo "from google.auth._default import _load_credentials_from_file" it should be "from google.auth._default import load_credentials_from_file" no underscore for "load_credentials_from_file" as google.auth._default has only load_credentials_from_file class. Such a wonderful contribution, thanks.